### PR TITLE
Support Unicode for explode- and implode-string

### DIFF
--- a/org.spoofax.interpreter.core/src/main/java/org/spoofax/interpreter/library/ssl/SSL_explode_string.java
+++ b/org.spoofax.interpreter.core/src/main/java/org/spoofax/interpreter/library/ssl/SSL_explode_string.java
@@ -35,8 +35,9 @@ public class SSL_explode_string extends AbstractPrimitive {
         ITermFactory factory = env.getFactory();
         IStrategoList result = factory.makeList();
         
-        for (int i = s.length() - 1; i >= 0; i--) {
-            result = factory.makeListCons(factory.makeInt(s.charAt(i)), result);
+        for (int i = s.length(), c; i > 0; i -= Character.charCount(c)) {
+            c = s.codePointBefore(i);
+            result = factory.makeListCons(factory.makeInt(c), result);
         }
         
         env.setCurrent(result);

--- a/org.spoofax.interpreter.core/src/main/java/org/spoofax/interpreter/library/ssl/SSL_implode_string.java
+++ b/org.spoofax.interpreter.core/src/main/java/org/spoofax/interpreter/library/ssl/SSL_implode_string.java
@@ -39,7 +39,7 @@ public class SSL_implode_string extends AbstractPrimitive {
 
         while (!chars.isEmpty()) {
             IStrategoInt v = (IStrategoInt) chars.head();
-            result.append((char) v.intValue());
+            result.appendCodePoint(v.intValue());
             chars = chars.tail();
         }
         return result.toString();


### PR DESCRIPTION
Related to metaborg/jsglr#72 and metaborg/sdf#38.

Uses `String.codePointBefore` and `StringBuilder.appendCodePoint` instead of `String.charAt` and `StringBuilder.append(char)`, respectively.

Semantics have not changed for `String`s containing only characters with Unicode value < 2¹⁶ (i.e. the ones fitting in one UTF-16 code unit). For characters with Unicode value ≥ 2¹⁶ (i.e. the ones represented by a pair of UTF-16 code units), the proper Unicode value is now used, instead of considering the two UTF-16 code units as separate characters.