### PR TITLE
Robust file resolution

### DIFF
--- a/org.metaborg.util/src/main/java/org/metaborg/util/resource/ResourceUtils.java
+++ b/org.metaborg.util/src/main/java/org/metaborg/util/resource/ResourceUtils.java
@@ -6,8 +6,10 @@ import java.util.Set;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.FileTypeSelector;
+import org.apache.commons.vfs2.NameScope;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 
@@ -91,18 +93,17 @@ public class ResourceUtils {
     }
 
     /**
-     * Robust version of FileOject::resolveFile(String), which accepts more complicated resource URLs than that method.
-     * For example, a URL of the form zip:file:///...!/... fails using FileObject::resolveFile(String), but works using
-     * this method.
-     * 
-     * @param base
-     *            The base resource, relative to which resource is resolved if resource is not an absolute path.
-     * @param resource
-     *            The resource to resolve, either absolute or relative.
-     * @return Resolved file object.
+     * Finds a file, relative to this file. The path can be either relative, or absolute. Unlike
+     * {@code FileObject::resolveFile( path )}, this method also resolves absolute paths into different file systems
+     * than that of the baseFile.
+     *
+     * @param path
+     *            The path of the file to locate. Can either be a relative path or an absolute path.
+     * @return The file.
      * @throws FileSystemException
+     *             On error parsing the path, or on error finding the file.
      */
-    public static FileObject resolveFileRobust(FileObject base, String resource) throws FileSystemException {
-        return base.getFileSystem().getFileSystemManager().resolveFile(base, resource);
+    public static FileObject resolveFile(FileObject baseFile, String name) throws FileSystemException {
+        return baseFile.getFileSystem().getFileSystemManager().resolveFile(baseFile, name);
     }
 }


### PR DESCRIPTION
The method `FileObject::resolveFile(String)` does not support absolute paths as
argument that are outside the file system of the base file. These PRs (in `releng`,
`mb-exec` and `spoofax`) replace uses of that method with the utility method
`ResourceUtils::resolveFile(FileObject, String)` that _does_ support cross file system
absolute paths.

This PR updates the utility method and its description.